### PR TITLE
Added support for protocol in GITLAB_HOST

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -3,7 +3,12 @@ set -x
 
 pid=0
 token=()
-gitlab_service_url=http://${GITLAB_HOST}
+
+if ! [[ $GITLAB_HOST =~ ^https?:// ]]; then
+  gitlab_service_url=http://${GITLAB_HOST}
+else
+  gitlab_service_url=${GITLAB_HOST}
+fi
 
 # SIGTERM-handler
 term_handler() {


### PR DESCRIPTION
By default, the runner prepends the host with http. If the host already contains a protocol, this is skipped.